### PR TITLE
using full name for docker images (not tagging them after pulling) so…

### DIFF
--- a/csl_docs/README.md
+++ b/csl_docs/README.md
@@ -217,7 +217,7 @@ version: '2.2'
 services:
 
   mw-sut-apachewp:
-    image: mw-sut-apachewp:latest
+    image: twosixlabsmagicwand/mw-sut-apachewp:latest
     privileged: true
     ports:
       - "80:80"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/apachekill/apachekill.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/apachekill/apachekill.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-apachekill:
-    image: mw-attack-apachekill:latest
+    image: twosixlabsmagicwand/mw-attack-apachekill:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/goloris/goloris.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/goloris/goloris.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-goloris:
-    image: mw-attack-goloris:latest
+    image: twosixlabsmagicwand/mw-attack-goloris:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/httpflood/httpflood.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/httpflood/httpflood.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-httpflood:
-    image: mw-attack-httpflood:latest
+    image: twosixlabsmagicwand/mw-attack-httpflood:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_rudeadyet/sht_rudeadyet.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_rudeadyet/sht_rudeadyet.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-sht-rudeadyet:
-    image: mw-attack-sht-rudeadyet:latest
+    image: twosixlabsmagicwand/mw-attack-sht-rudeadyet:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_slowloris/sht_slowloris.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_slowloris/sht_slowloris.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-sht-slowloris:
-    image: mw-attack-sht-slowloris:latest
+    image: twosixlabsmagicwand/mw-attack-sht-slowloris:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_slowread/sht_slowread.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/sht_slowread/sht_slowread.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-sht-slowread:
-    image: mw-attack-sht-slowread:latest
+    image: twosixlabsmagicwand/mw-attack-sht-slowread:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/sockstress/sockstress.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/sockstress/sockstress.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-sockstress:
-    image: mw-attack-sockstress:latest
+    image: twosixlabsmagicwand/mw-attack-sockstress:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/attacks/synflood/synflood.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/attacks/synflood/synflood.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-attack-synflood:
-    image: mw-attack-synflood:latest
+    image: twosixlabsmagicwand/mw-attack-synflood:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/benign/mw_locust/mw_locust.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/benign/mw_locust/mw_locust.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
     
   mw-client-smartswarm:
-    image: mw-client-smartswarm:latest
+    image: twosixlabsmagicwand/mw-client-smartswarm:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/sensors/mw_rtt_sensor/mw_rtt_sensor.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/sensors/mw_rtt_sensor/mw_rtt_sensor.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-client-rtt-tracker:
-    image: mw-client-rtt-tracker:latest
+    image: twosixlabsmagicwand/mw-client-rtt-tracker:latest
     privileged: true
     depends_on:
       - "mw-sut-apachewp"

--- a/magicwand-data-generator/magicwand/magicwand_components/suts/mw_apache_wp/mw_apache_wp.yml
+++ b/magicwand-data-generator/magicwand/magicwand_components/suts/mw_apache_wp/mw_apache_wp.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
 
   mw-sut-apachewp:
-    image: mw-sut-apachewp:latest
+    image: twosixlabsmagicwand/mw-sut-apachewp:latest
     privileged: true
     ports:
       - "80:80"

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -1,36 +1,15 @@
-echo "Pulling and tagging images"
+echo "Pulling images"
 
 docker pull twosixlabsmagicwand/mw-client-smartswarm
-docker tag twosixlabsmagicwand/mw-client-smartswarm mw-client-smartswarm
-
 docker pull twosixlabsmagicwand/mw-client-rtt-tracker
-docker tag twosixlabsmagicwand/mw-client-rtt-tracker mw-client-rtt-tracker
-
 docker pull twosixlabsmagicwand/mw-cic-converter
-docker tag twosixlabsmagicwand/mw-cic-converter mw-cic-converter
-
 docker pull twosixlabsmagicwand/mw-attack-sht-slowread
-docker tag twosixlabsmagicwand/mw-attack-sht-slowread mw-attack-sht-slowread
-
 docker pull twosixlabsmagicwand/mw-attack-synflood
-docker tag twosixlabsmagicwand/mw-attack-synflood mw-attack-synflood
-
 docker pull twosixlabsmagicwand/mw-attack-sockstress
-docker tag twosixlabsmagicwand/mw-attack-sockstress mw-attack-sockstress
-
 docker pull twosixlabsmagicwand/mw-attack-apachekill
-docker tag twosixlabsmagicwand/mw-attack-apachekill mw-attack-apachekill
-
 docker pull twosixlabsmagicwand/mw-attack-sht-slowloris
-docker tag twosixlabsmagicwand/mw-attack-sht-slowloris mw-attack-sht-slowloris
-
 docker pull twosixlabsmagicwand/mw-attack-httpflood
-docker tag twosixlabsmagicwand/mw-attack-httpflood mw-attack-httpflood
-
 docker pull twosixlabsmagicwand/mw-sut-apachewp
-docker tag twosixlabsmagicwand/mw-sut-apachewp mw-sut-apachewp
-
 docker pull twosixlabsmagicwand/mw-sut-apachewp-plain
-docker tag twosixlabsmagicwand/mw-sut-apachewp-plain mw-sut-apachewp-plain 
 
-echo "Done pulling and tagging images"
+echo "Done pulling images"


### PR DESCRIPTION
Currently, you need to call the `pull_images.sh` script before running the data tool. Otherwise, it will fail because the images aren't available locally. However, if we skip the step of tagging the images and leave them with the full name then the data tool will pull the images from docker hub automatically.